### PR TITLE
Adds test-unit to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source "http://rubygems.org"
 
 group(:test) do
   gem('rake', '>= 0.9.2')
+  gem('test-unit', '>= 3.1.8')
   gem('ffi-geos', '>= 0.0.4')
   gem('rgeo', '>= 0.3.13')
   gem('rdoc', '>= 3.12')


### PR DESCRIPTION
When first cloning this repository and executing the following:

```
bundle install
bundle exec rake test
```

the user is met with an error related to `test/unit` being a file
that does not exist during the require at the top of the first test
file.  Adding this to the Gemfile and rebundling resolves the issue.